### PR TITLE
Fix: typo in fn name & global path table

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -27,7 +27,7 @@ end)
 mod.hook.register("script_pre_init", "my init hacks", function()
   for n=1,4 do
     grid.vports[n]:intensity(state.intensity[n])
-    grid.vports[n]:rotatoin(state.rotation[n])
+    grid.vports[n]:rotation(state.rotation[n])
   end
 end)
 
@@ -51,7 +51,7 @@ m.enc = function(n, d)
   if n == 2 then i = util.clamp(i+d,1,4)
   elseif n == 3 then
     state.intensity[i] = util.clamp(state.intensity[i]+d,0,15)
-    grid.vports[i]:intensity(state.intensity[i]) 
+    grid.vports[i]:intensity(state.intensity[i])
   end
   mod.menu.redraw()
 end

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -6,15 +6,15 @@ local state = {
 }
 
 mod.hook.register("system_post_startup", "read grid-settings", function()
-  local f = io.open(_path.data..'grid-settings.state')
+  local f = io.open(paths.data..'grid-settings.state')
   if f ~= nil then
     io.close(f)
-    state = dofile(_path.data..'grid-settings.state')
+    state = dofile(paths.data..'grid-settings.state')
   end
 end)
 
 mod.hook.register("system_pre_shutdown", "write grid-settings", function()
-  local f = io.open(_path.data..'grid-settings.state',"w+")
+  local f = io.open(paths.data..'grid-settings.state',"w+")
   io.output(f)
   io.write("return { intensity={")
   for n=1,4 do io.write(state.intensity[n]..",") end

--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -6,10 +6,10 @@ local state = {
 }
 
 mod.hook.register("system_post_startup", "read grid-settings", function()
-  local f = io.open(path.data..'grid-settings.state')
+  local f = io.open(_path.data..'grid-settings.state')
   if f ~= nil then
     io.close(f)
-    state = dofile(path.data..'grid-settings.state')
+    state = dofile(_path.data..'grid-settings.state')
   end
 end)
 


### PR DESCRIPTION
- `rotation` instead of `rotatoin`
- ~~`_path`~~ `paths` instead of `path`